### PR TITLE
Refine the API; bump to version 2

### DIFF
--- a/ValueTypes/Enumerables.fs
+++ b/ValueTypes/Enumerables.fs
@@ -4,6 +4,16 @@ open System.Collections.Generic
 
 [<RequireQualifiedAccess>]
 module Enumerables =
+
+    [<Struct>]    
+    type ArrayValueSeq<'a> (array : 'a array) =
+        interface ValueSeq<'a, Enumerators.Array<'a>> with
+            member this.GetEnumerator () = new Enumerators.Array<'a>(array)
+
+    [<Struct>]    
+    type ListValueSeq<'a> (list : 'a list) =
+        interface ValueSeq<'a, Enumerators.List<'a>> with
+            member this.GetEnumerator () = new Enumerators.List<'a>(list)
     
     [<Struct>]
     type SkippedValueSeq<'a, 'enumerator, 'enumerable
@@ -12,10 +22,10 @@ module Enumerables =
         and 'enumerable :> ValueSeq<'a, 'enumerator>>
         (count : int, enumerable : 'enumerable)
         =
-        interface ValueSeq<'a, Enumerators.SkippingEnumerator<'a, 'enumerator>> with
+        interface ValueSeq<'a, Enumerators.Skipping<'a, 'enumerator>> with
             member this.GetEnumerator () =
                 let enumerator = enumerable.GetEnumerator ()
-                new Enumerators.SkippingEnumerator<'a, _>(count, enumerator)
+                new Enumerators.Skipping<'a, _>(count, enumerator)
     
     [<Struct>]
     type TruncatedValueSeq<'a, 'enumerator, 'enumerable
@@ -24,8 +34,19 @@ module Enumerables =
         and 'enumerable :> ValueSeq<'a, 'enumerator>>
         (count : int, enumerable : 'enumerable)
         =
-        interface ValueSeq<'a, Enumerators.TruncatingEnumerator<'a, 'enumerator>> with
+        interface ValueSeq<'a, Enumerators.Truncating<'a, 'enumerator>> with
             member this.GetEnumerator () =
                 let enumerator = enumerable.GetEnumerator ()
-                new Enumerators.TruncatingEnumerator<'a, _>(count, enumerator)
+                new Enumerators.Truncating<'a, _>(count, enumerator)
 
+    [<Struct>]
+    type PredicatedValueSeq<'a, 'enumerator, 'enumerable
+        when 'enumerator :> IEnumerator<'a>
+        and 'enumerator : struct
+        and 'enumerable :> ValueSeq<'a, 'enumerator>>
+        (predicate : 'a -> bool, enumerable : 'enumerable)
+        =
+        interface ValueSeq<'a, Enumerators.Predicated<'a, 'enumerator>> with
+            member this.GetEnumerator () =
+                let enumerator = enumerable.GetEnumerator()
+                new Enumerators.Predicated<'a, _>(predicate, enumerator)

--- a/ValueTypes/Enumerables.fsi
+++ b/ValueTypes/Enumerables.fsi
@@ -5,21 +5,39 @@ open System.Collections.Generic
 [<RequireQualifiedAccess>]
 module Enumerables =
 
-    [<Struct>]
+    [<Struct; NoEquality; NoComparison>]
+    type 'a ArrayValueSeq =
+        new : 'a array -> 'a ArrayValueSeq
+        interface ValueSeq<'a, 'a Enumerators.Array>
+    
+    [<Struct; NoEquality; NoComparison>]
+    type 'a ListValueSeq =
+        new : 'a list -> 'a ListValueSeq
+        interface ValueSeq<'a, 'a Enumerators.List>
+    
+    [<Struct; NoEquality; NoComparison>]
     type SkippedValueSeq<'a, 'enumerator, 'enumerable
         when 'enumerator :> IEnumerator<'a>
         and 'enumerator : struct
         and 'enumerable :> ValueSeq<'a, 'enumerator>>
         =
         new : int * 'enumerable -> SkippedValueSeq<'a, 'enumerator, 'enumerable>
-        interface ValueSeq<'a, Enumerators.SkippingEnumerator<'a, 'enumerator>>
+        interface ValueSeq<'a, Enumerators.Skipping<'a, 'enumerator>>
     
-    [<Struct>]
+    [<Struct; NoEquality; NoComparison>]
     type TruncatedValueSeq<'a, 'enumerator, 'enumerable
         when 'enumerator :> IEnumerator<'a>
         and 'enumerator : struct
         and 'enumerable :> ValueSeq<'a, 'enumerator>>
         =
         new : int * 'enumerable -> TruncatedValueSeq<'a, 'enumerator, 'enumerable>
-        interface ValueSeq<'a, Enumerators.TruncatingEnumerator<'a, 'enumerator>>
+        interface ValueSeq<'a, Enumerators.Truncating<'a, 'enumerator>>
         
+    [<Struct; NoEquality; NoComparison>]
+    type PredicatedValueSeq<'a, 'enumerator, 'enumerable
+        when 'enumerator :> IEnumerator<'a>
+        and 'enumerator : struct
+        and 'enumerable :> ValueSeq<'a, 'enumerator>>
+        =
+        new : ('a -> bool) * 'enumerable -> PredicatedValueSeq<'a, 'enumerator, 'enumerable>
+        interface ValueSeq<'a, Enumerators.Predicated<'a, 'enumerator>>

--- a/ValueTypes/Enumerators.fsi
+++ b/ValueTypes/Enumerators.fsi
@@ -7,40 +7,53 @@ module Enumerators =
 
     /// Value-type enumerator for an array
     [<Struct>]
-    type 'a ArrayEnumerator =
+    type 'a Array =
         val private array : 'a array
         val mutable private currentIndex : int
-        new : 'a array -> 'a ArrayEnumerator
+        new : 'a array -> 'a Array
         interface 'a IEnumerator
 
     /// Value-type enumerator for a list
     [<Struct>]
-    type 'a ListEnumerator =
+    type 'a List =
         val private list : 'a list
         val mutable private currentHead : 'a list voption
-        new : 'a list -> 'a ListEnumerator
+        new : 'a list -> 'a List
         interface 'a IEnumerator
 
     /// Value-type enumerator that skips the first n elements of another value-type enumerator
     [<Struct>]
-    type SkippingEnumerator<'a, 'enumerator
+    type Skipping<'a, 'enumerator
         when 'enumerator :> IEnumerator<'a>
         and 'enumerator : struct>
         =
         val private skip : int
         val mutable private enumerator : 'enumerator
         val mutable private skippingDone : bool
-        new : int * 'enumerator -> SkippingEnumerator<'a, 'enumerator>
+        new : int * 'enumerator -> Skipping<'a, 'enumerator>
         interface 'a IEnumerator
     
     /// Value-type enumerator that truncates to the first n elements of another value-type enumerator    
     [<Struct>]
-    type TruncatingEnumerator<'a, 'enumerator
+    type Truncating<'a, 'enumerator
         when 'enumerator :> IEnumerator<'a>
         and 'enumerator : struct>
         =
         val private truncateTo : int
         val mutable private enumerator : 'enumerator
         val mutable private counter : int
-        new : int * 'enumerator -> TruncatingEnumerator<'a, 'enumerator>
+        new : int * 'enumerator -> Truncating<'a, 'enumerator>
         interface 'a IEnumerator
+        
+    /// Value-type enumerator that takes elements of another value-type enumerator as long as the provided predicate
+    /// function returns true
+    [<Struct>]
+    type Predicated<'a, 'enumerator
+        when 'enumerator :> IEnumerator<'a>
+        and 'enumerator : struct>
+        =
+        val private predicate : 'a -> bool
+        val mutable private enumerator : 'enumerator
+        val mutable private moreItems : bool
+        new : ('a -> bool) * 'enumerator -> Predicated<'a, 'enumerator>
+        interface 'a IEnumerator 

--- a/ValueTypes/Test/BenchmarkDotNetHelpers.fs
+++ b/ValueTypes/Test/BenchmarkDotNetHelpers.fs
@@ -12,7 +12,7 @@ module BenchmarkDotNetHelpers =
     /// This is intended for running tests that check that code doesn't allocate; it shouldn't be used for actual benchmarking.
     let coldStartSingleRunConfig =
         ManualConfig.Create(DefaultConfig.Instance)
-            .With(ConfigOptions.DisableOptimizationsValidator) // We don't mind testing for allocation free code in DEBUG.
+            //.With(ConfigOptions.DisableOptimizationsValidator) // We don't mind testing for allocation free code in DEBUG.
             .With(Job.Default
                       .WithLaunchCount(1)
                       .WithIterationCount(1))

--- a/ValueTypes/Test/ValueSeqAllocationTests.fs
+++ b/ValueTypes/Test/ValueSeqAllocationTests.fs
@@ -22,17 +22,17 @@ module ValueSeqAllocationTests =
 
         [<Benchmark>]
         member this.LengthofArray () =
-            let length = ValueSeq.count arrayBackedData.Value
+            let _ = ValueSeq.count arrayBackedData.Value
             ()
 
         [<Benchmark>]
         member this.LengthOfList () =
-            let length = listBackedData.Value |> ValueSeq.count
+            let _ = listBackedData.Value |> ValueSeq.count
             ()
 
         [<Benchmark>]
         member this.TryHead () =
-            let head = arrayBackedData.Value |> ValueSeq.tryHead |> ValueOption.get
+            let _ = arrayBackedData.Value |> ValueSeq.tryHead |> ValueOption.get
             ()
 
         member val IterAction =
@@ -45,7 +45,7 @@ module ValueSeqAllocationTests =
 
         member val IteriAction =
             let mutable counter = 0
-            (fun x i -> counter <- counter + x) |> id
+            (fun x _ -> counter <- counter + x) |> id
 
         [<Benchmark>]
         member this.Iteri () =
@@ -56,25 +56,7 @@ module ValueSeqAllocationTests =
 
         [<Benchmark>]
         member this.Fold () =
-            let sum = arrayBackedData.Value |> ValueSeq.fold this.FoldAction 0
-            ()
-
-        [<Benchmark>]
-        member this.Foldn () =
-            let sum = arrayBackedData.Value |> ValueSeq.foldn 4 this.FoldAction 0
-            ()
-
-        [<Benchmark>]
-        member this.FoldFromN () =
-            let sum = arrayBackedData.Value |> ValueSeq.foldFromN 4 this.FoldAction 0
-            ()
-
-        member val FoldPredicate =
-            (fun _ _ -> true) |> id
-
-        [<Benchmark>]
-        member this.FoldWhile () =
-            let sum = arrayBackedData.Value |> ValueSeq.foldWhile this.FoldPredicate this.FoldAction 0
+            let _ = arrayBackedData.Value |> ValueSeq.fold this.FoldAction 0
             ()
 
     [<Test>]

--- a/ValueTypes/Test/ValueSeqTests.fs
+++ b/ValueTypes/Test/ValueSeqTests.fs
@@ -57,49 +57,40 @@ module ValueSeqTests =
     let ``Test ValueSeq.fold over an array`` array =
         array |> ValueSeq.ofArray |> ValueSeq.fold (+) 0
 
-    [<TestCaseSource("arraysForSumming")>]
-    let ``Test ValueSeq.foldi over an array`` array =
-        let mutable lastIndex = -1
-        let folder sum index value =
-            index |> should equal (lastIndex + 1)
-            lastIndex <- index
-            sum + value
-        array |> ValueSeq.ofArray |> ValueSeq.foldi folder 0
-
     [<Test>]
     let ``Test ValueSeq.foldn over a longer than n sequence`` () =
         let array = [| 1; 2; 4; 8; 16 |]
-        array |> ValueSeq.ofArray |> ValueSeq.foldn 3 (+) 0 |> should equal 7
+        array |> ValueSeq.ofArray |> ValueSeq.truncate 3 |> ValueSeq.fold (+) 0 |> should equal 7
 
     [<Test>]
     let ``Test ValueSeq.foldn over a length = n sequence`` () =
         let array = [| 1; 2; 4; 8; 16 |]
-        array |> ValueSeq.ofArray |> ValueSeq.foldn 5 (+) 0 |> should equal 31
+        array |> ValueSeq.ofArray |> ValueSeq.truncate 5 |> ValueSeq.fold (+) 0 |> should equal 31
 
     [<Test>]
     let ``Test ValueSeq.foldn over a shorter than n sequence`` () =
         let array = [| 1; 2; 4; 8; 16 |]
-        array |> ValueSeq.ofArray |> ValueSeq.foldn 6 (+) 0 |> should equal 31
+        array |> ValueSeq.ofArray |> ValueSeq.truncate 6 |> ValueSeq.fold (+) 0 |> should equal 31
 
     [<Test>]
     let ``Test ValueSeq.foldFromN over a longer than n sequence`` () =
         let array = [| 1; 2; 4; 8; 16 |]
-        array |> ValueSeq.ofArray |> ValueSeq.foldFromN 3 (+) 0 |> should equal 28
+        array |> ValueSeq.ofArray |> ValueSeq.skip 2 |> ValueSeq.fold (+) 0 |> should equal 28
 
     [<Test>]
     let ``Test ValueSeq.foldFromN over a length = n sequence`` () =
         let array = [| 1; 2; 4; 8; 16 |]
-        array |> ValueSeq.ofArray |> ValueSeq.foldFromN 5 (+) 0 |> should equal 16
+        array |> ValueSeq.ofArray |> ValueSeq.skip 4 |> ValueSeq.fold (+) 0 |> should equal 16
 
     [<Test>]
     let ``Test ValueSeq.foldFromN over a shorter than n sequence`` () =
         let array = [| 1; 2; 4; 8; 16 |]
-        array |> ValueSeq.ofArray |> ValueSeq.foldFromN 6 (+) 0 |> should equal 0
+        array |> ValueSeq.ofArray |> ValueSeq.skip 5 |> ValueSeq.fold (+) 0 |> should equal 0
 
     [<Test>]
     let ``TestValueSeq.foldWhile sum the values as long as the sum is less than the value`` () =
         let array = [| 1; 2; 3; 4 |]
-        array |> ValueSeq.ofArray |> ValueSeq.foldWhile (fun sum item -> item >= sum) (+) 0 |> should equal 6
+        array |> ValueSeq.ofArray |> ValueSeq.takeWhile ((>) 4) |> ValueSeq.fold (+) 0 |> should equal 6
 
     [<Test>]
     let ``Test ValueSeq.tryHead with a value`` () =

--- a/ValueTypes/Test/ValueSeqTransformAllocationTests.fs
+++ b/ValueTypes/Test/ValueSeqTransformAllocationTests.fs
@@ -29,6 +29,14 @@ module ValueSeqTransformAllocationTests =
             let first4 = ValueSeq.truncate 4 arrayBackedData.Value
             let _ = ValueSeq.fold this.FoldAction 0 first4
             ()
+        
+        member val Predicate = (fun x -> not(x = 4)) |> id
+            
+        [<Benchmark>]
+        member this.TakeWhile () =
+            let until4 = ValueSeq.takeWhile this.Predicate arrayBackedData.Value
+            let _ = ValueSeq.fold this.FoldAction 0 until4
+            ()
 
     [<Test>]
     let runTests () = BenchmarkDotNetHelpers.assertAllocationFree<ValueSeqTransformAllocationBenchmark> ()

--- a/ValueTypes/Test/ValueSeqTransformTests.fs
+++ b/ValueTypes/Test/ValueSeqTransformTests.fs
@@ -91,3 +91,40 @@ module ValueSeqTransformTests =
         |> ValueSeq.truncate 2
         |> ValueSeq.toSeq
         |> should equal [2; 4]
+        
+    //
+    // ValueSeq.takeWhile tests
+    //
+    
+    [<TestCase(true)>]
+    [<TestCase(false)>]
+    let ``Test taking from an empty sequence`` predicateValue =
+        []
+        |> ValueSeq.ofList
+        |> ValueSeq.takeWhile (fun _ -> predicateValue)
+        |> ValueSeq.toSeq
+        |> should be Empty
+        
+    [<Test>]
+    let ``Test taking everything`` () =
+        [1; 2; 4; 8]
+        |> ValueSeq.ofList
+        |> ValueSeq.takeWhile (fun _ -> true)
+        |> ValueSeq.toSeq
+        |> should equal [1; 2; 4; 8]
+        
+    [<Test>]
+    let ``Test taking nothing`` () =
+        [1; 2; 4; 8]
+        |> ValueSeq.ofList
+        |> ValueSeq.takeWhile (fun _ -> false)
+        |> ValueSeq.toSeq
+        |> should be Empty
+        
+    [<Test>]
+    let ``Test taking some items`` () =
+        [1; 2; 4; 8]
+        |> ValueSeq.ofList
+        |> ValueSeq.takeWhile (fun x -> not (x = 4))
+        |> ValueSeq.toSeq
+        |> should equal [1; 2]

--- a/ValueTypes/ValueSeq.fs
+++ b/ValueTypes/ValueSeq.fs
@@ -13,7 +13,7 @@ module ValueSeq =
         enumerable.GetEnumerator ()
 
     [<CompiledName("Count")>]
-    let count (source : ValueSeq<_,_>) : int =
+    let count (source : #ValueSeq<_,_>) : int =
         let mutable iter = source |> getIterator
         let mutable counter = 0
 
@@ -22,17 +22,17 @@ module ValueSeq =
         counter
 
     [<CompiledName("TryHead")>]
-    let tryHead (source : ValueSeq<'a,_>) : 'a voption =
+    let tryHead (source : #ValueSeq<'a,_>) : 'a voption =
         let mutable iter = source |> getIterator
         if iter.MoveNext () then ValueSome iter.Current else ValueNone
 
-    [<CompiledName("Iter")>]
-    let iter (action : 'a -> unit) (source : ValueSeq<'a,_>) : unit =
+    [<CompiledName("Iterate")>]
+    let iter (action : 'a -> unit) (source : #ValueSeq<'a,_>) : unit =
         let mutable iter = source |> getIterator
         while iter.MoveNext() do iter.Current |> action
 
-    [<CompiledName("Iteri")>]
-    let iteri (action : int -> 'a -> unit) (source : ValueSeq<'a,_>) : unit =
+    [<CompiledName("IterateIndexed")>]
+    let iteri (action : int -> 'a -> unit) (source : #ValueSeq<'a,_>) : unit =
         let mutable iter = source |> getIterator
         let mutable index = -1
         while iter.MoveNext() do
@@ -53,58 +53,14 @@ module ValueSeq =
             currentState <- folder currentState iter.Current
         currentState
 
-    [<CompiledName("Foldi")>]
-    let foldi (folder : 'state -> int -> 'a -> 'state) (state : 'state) (source : ValueSeq<'a,_>) : 'state =
-        let mutable iter = source |> getIterator
-        let mutable currentState = state
-        let mutable index = -1
-
-        while iter.MoveNext() do
-            index <- index + 1
-            currentState <- folder currentState index iter.Current
-        currentState
-
-    [<CompiledName("Foldn")>]
-    let foldn (n : int) (folder : 'state -> 'a -> 'state) (state: 'state) (source : ValueSeq<'a,_>) : 'state =
-        let mutable iter = source |> getIterator
-        let mutable currentState = state
-        let mutable counter = 0
-
-        while counter < n && iter.MoveNext() do
-            counter <- counter + 1
-            currentState <- folder currentState iter.Current
-        currentState
-
-    [<CompiledName("FoldFromN")>]
-    let foldFromN (n : int) (folder : 'state -> 'a -> 'state) (state: 'state) (source : ValueSeq<'a,_>) : 'state =
-        let mutable iter = source |> getIterator
-        let mutable currentState = state
-        let mutable counter = 0
-
-        // Iterate until at the (n-1)th element
-        while counter < (n-1) && iter.MoveNext() do
-            counter <- counter + 1
-
-        // Now fold until there are no more elements
-        while iter.MoveNext() do
-            currentState <- folder currentState iter.Current
-        currentState
-
-    [<CompiledName("FoldWhile")>]
-    let foldWhile
-        (predicate : 'state -> 'a -> bool)
-        (folder : 'state -> 'a -> 'state)
-        (state: 'state)
-        (source : ValueSeq<'a,_>) :
-        'state
+    [<CompiledName("TakeWhile")>]
+    let takeWhile
+        (predicate : 'a -> bool)
+        (source : #ValueSeq<'a, 'enumerator>)
+        : Enumerables.PredicatedValueSeq<_,_,_>
         =
-        let mutable iter = source |> getIterator
-        let mutable currentState = state
-
-        while iter.MoveNext() && (predicate currentState iter.Current) do
-            currentState <- folder currentState iter.Current
-        currentState
-
+        Enumerables.PredicatedValueSeq(predicate, source)
+    
     [<CompiledName("Skip")>]
     let skip
         (count : int)
@@ -121,25 +77,16 @@ module ValueSeq =
         =
         Enumerables.TruncatedValueSeq(count, source)
     
-    type ArrayEnumerable<'a> (array : 'a array) =
-        interface ValueSeq<'a, Enumerators.ArrayEnumerator<'a>> with
-            member this.GetEnumerator () = new Enumerators.ArrayEnumerator<'a>(array)
-
     [<CompiledName("OfArray")>]
-    let ofArray (array : 'a array) : ValueSeq<'a,_>=
-        array |> ArrayEnumerable :> _
-
-
-    type ListEnumerable<'a> (list : 'a list) =
-        interface ValueSeq<'a, Enumerators.ListEnumerator<'a>> with
-            member this.GetEnumerator () = new Enumerators.ListEnumerator<'a>(list)
+    let ofArray (array : 'a array) =
+        Enumerables.ArrayValueSeq(array)
 
     [<CompiledName("OfList")>]
-    let ofList (list : 'a list) : ValueSeq<'a,_> =
-        list |> ListEnumerable :> _
+    let ofList (list : 'a list) =
+        Enumerables.ListValueSeq(list)
 
     [<CompiledName("ToSeq")>]
-    let toSeq (source : ValueSeq<'a,'enumerator>) : 'a seq =
+    let toSeq (source : #ValueSeq<'a, _>) : 'a seq =
         seq {
             let mutable iter = source |> getIterator
             while iter.MoveNext() do yield iter.Current

--- a/ValueTypes/ValueSeq.fsi
+++ b/ValueTypes/ValueSeq.fsi
@@ -8,87 +8,82 @@ module ValueSeq =
 
     /// Count the number of element in the sequence
     [<CompiledName("Count")>]
-    val count<'a, 'enumerator when 'enumerator :> IEnumerator<'a> and 'enumerator : struct> :
-        source : ValueSeq<'a, 'enumerator>
-        -> int
+    val count<'enumerable, 'a, 'enumerator
+        when 'enumerator :> IEnumerator<'a>
+        and 'enumerator : struct
+        and 'enumerable :> ValueSeq<'a, 'enumerator>>
+        :
+        source : 'enumerable ->
+        int
 
     /// If the sequence is non-empty, get its first element, otherwise return ValueNone
     [<CompiledName("TryHead")>]
-    val tryHead<'a, 'enumerator when 'enumerator :> IEnumerator<'a> and 'enumerator : struct> :
-        source : ValueSeq<'a, 'enumerator>
-        -> 'a voption
+    val tryHead<'enumerable, 'a, 'enumerator
+        when 'enumerator :> IEnumerator<'a>
+        and 'enumerator : struct
+        and 'enumerable :> ValueSeq<'a, 'enumerator>>
+        :
+        source : 'enumerable ->
+        'a voption
 
     /// Iterate through the sequence, applying the given action to each element
-    [<CompiledName("Iter")>]
-    val iter<'a, 'enumerator when 'enumerator :> IEnumerator<'a> and 'enumerator : struct> :
+    [<CompiledName("Iterate")>]
+    val iter<'a, 'enumerable, 'enumerator
+        when 'enumerator :> IEnumerator<'a>
+        and 'enumerator : struct
+        and 'enumerable :> ValueSeq<'a, 'enumerator>>
+        :
         action : ('a -> unit) ->
-        source : ValueSeq<'a, 'enumerator>
-        -> unit
+        source : 'enumerable ->
+        unit
 
     /// Iterate through the ValueSeq, applying the given action to each element. The action is passed the element's index
     /// in addition to the element itself
-    [<CompiledName("Iteri")>]
-    val iteri<'a, 'enumerator when 'enumerator :> IEnumerator<'a> and 'enumerator : struct> :
-        action : (int -> 'a -> unit) -> ValueSeq<'a, 'enumerator> -> unit
+    [<CompiledName("IterateIndexed")>]
+    val iteri<'a, 'enumerable, 'enumerator
+        when 'enumerator :> IEnumerator<'a>
+        and 'enumerator : struct
+        and 'enumerable :> ValueSeq<'a, 'enumerator>>
+        :
+        action : (int -> 'a -> unit) ->
+        source : 'enumerable ->
+        unit
 
     /// Fold over the given ValueSeq
     [<CompiledName("Fold")>]
     val fold<'state, 'a, 'enumerable, 'enumerator
         when 'enumerator :> IEnumerator<'a>
         and 'enumerator : struct
-        and 'enumerable :> ValueSeq<'a, 'enumerator>> :
+        and 'enumerable :> ValueSeq<'a, 'enumerator>>
+        :
         folder : ('state -> 'a -> 'state) ->
         initState : 'state ->
-        source : 'enumerable
-        -> 'state
+        source : 'enumerable ->
+        'state
 
-    /// Fold over the given ValueSeq, passing in the current index to the folder function
-    [<CompiledName("Foldi")>]
-    val foldi<'state, 'a, 'enumerator when 'enumerator :> IEnumerator<'a> and 'enumerator : struct> :
-        folder : ('state -> int -> 'a -> 'state) ->
-        initState : 'state ->
-        source : ValueSeq<'a, 'enumerator>
-        -> 'state
-
-    /// Fold over at most n elements from the given ValueSeq.
-    [<CompiledName("Foldn")>]
-    val foldn<'state, 'a, 'enumerator when 'enumerator :> IEnumerator<'a> and 'enumerator : struct> :
-        n : int ->
-        folder : ('state -> 'a -> 'state) ->
-        initState : 'state ->
-        source : ValueSeq<'a, 'enumerator>
-        -> 'state
-
-    /// Fold over the given ValueSeq, skipping over the first n-1 elements.
-    /// If there are less than n elements then this is the same as folding over an empty ValueSeq.
-    [<CompiledName("FoldFromN")>]
-    val foldFromN<'state, 'a, 'enumerator when 'enumerator :> IEnumerator<'a> and 'enumerator : struct> :
-        n : int ->
-        folder : ('state -> 'a -> 'state) ->
-        initState : 'state ->
-        source : ValueSeq<'a, 'enumerator>
-        -> 'state
-
-    /// Fold over the given ValueSeq, as long as the predicate function holds.
-    /// The predicate function is evaluated *before* the folder.
-    [<CompiledName("FoldWhile")>]
-    val foldWhile<'state, 'a, 'enumerator when 'enumerator :> IEnumerator<'a> and 'enumerator : struct> :
-        predicate : ('state -> 'a -> bool) ->
-        folder : ('state -> 'a -> 'state) ->
-        initState : 'state ->
-        source : ValueSeq<'a, 'enumerator>
-        -> 'state
-
+    /// Returns a ValueSeq that contains only elements of the provided ValueSeq for which the passed in predicate
+    /// returned true. In other words: elements up until the first element that returned false.
+    [<CompiledName("TakeWhile")>]
+    val takeWhile<'a, 'enumerable, 'enumerator
+        when 'enumerator :> IEnumerator<'a>
+        and 'enumerator : struct
+        and 'enumerable :> ValueSeq<'a, 'enumerator>>
+        :
+        predicate : ('a -> bool) ->
+        source : 'enumerable ->
+        Enumerables.PredicatedValueSeq<'a, 'enumerator, 'enumerable>
+    
     /// Return a ValueSeq that ignores the first 'count' elements of the passed in ValueSeq.
     /// If the provided ValueSeq has less than 'count' elements, the empty sequence is reuturned.
     [<CompiledName("Skip")>]
     val skip<'enumerable, 'a, 'enumerator
         when 'enumerator :> IEnumerator<'a>
         and 'enumerator : struct
-        and 'enumerable :> ValueSeq<'a, 'enumerator>> :
+        and 'enumerable :> ValueSeq<'a, 'enumerator>>
+        :
         count : int ->
-        source : 'enumerable
-        -> Enumerables.SkippedValueSeq<'a, 'enumerator, 'enumerable>
+        source : 'enumerable ->
+        Enumerables.SkippedValueSeq<'a, 'enumerator, 'enumerable>
 
     /// Return a ValueSeq only iterates over the first 'count' elements of the passed in ValueSeq.
     /// If the provided ValueSeq has less than 'count' elements, then this is in effect a no-op.
@@ -96,29 +91,34 @@ module ValueSeq =
     val truncate<'enumerable, 'a, 'enumerator
         when 'enumerator :> IEnumerator<'a>
         and 'enumerator : struct
-        and 'enumerable :> ValueSeq<'a, 'enumerator>> :
+        and 'enumerable :> ValueSeq<'a, 'enumerator>>
+        :
         count : int ->
-        source : 'enumerable
-        -> Enumerables.TruncatedValueSeq<'a, 'enumerator, 'enumerable>
+        source : 'enumerable ->
+        Enumerables.TruncatedValueSeq<'a, 'enumerator, 'enumerable>
     
     /// Returns a ValueSeq enumerable backed by the given array
     [<CompiledName("OfArray")>]
     val ofArray<'a> :
-        array : 'a array
-        -> ValueSeq<'a, Enumerators.ArrayEnumerator<'a>>
+        array : 'a array ->
+        'a Enumerables.ArrayValueSeq
 
     /// Returns a ValueSeq enumerable backed by the given list
     [<CompiledName("OfList")>]
     val ofList<'a> :
-        list : 'a list
-        -> ValueSeq<'a, Enumerators.ListEnumerator<'a>>
+        list : 'a list ->
+        'a Enumerables.ListValueSeq
 
     /// Wrap up the value-type sequence as a regular seq enumerable
     /// Note: this definitely allocates when used
     [<CompiledName("ToSeq")>]
-    val toSeq<'a, 'enumerator when 'enumerator :> IEnumerator<'a> and 'enumerator : struct> :
-        source : ValueSeq<'a, 'enumerator>
-        -> 'a seq
+    val toSeq<'enumerable, 'a, 'enumerator
+        when 'enumerator :> IEnumerator<'a>
+        and 'enumerator : struct
+        and 'enumerable :> ValueSeq<'a, 'enumerator>>
+        :
+        source : 'enumerable ->
+        'a seq
 
 
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "2.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
* Remove non-standard API functions (e.g. foldn) and replace them with composable ones (e.g. truncate + fold).
* Make sure that the ValueSeq functions do not box the ValueSeq they're passed (some were).
* Bump up the version root to 2.0

Most of this is deleting functions and renaming a few things