### PR TITLE
Fix the Appveyor build version number; add a NuGet package version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/71k4am4yauin1gba/branch/master?svg=true)](https://ci.appveyor.com/project/G-Research/peregrine/branch/master)
 
 This is the home of the Peregrine series of code for real-time and performant applications. It consists of:
-* [Peregrine.ValueTypes](ValueTypes) - F# functions for manipulating data strucures in ways that don't allocate
+* [Peregrine.ValueTypes](ValueTypes) - F# functions for manipulating data strucures in ways that don't allocate.
+
+## Current Releases
+
+[![Version](https://img.shields.io/nuget/v/PeregrineValueTypes.svg?label=PeregrineValueTypes)](https://www.nuget.org/packages/PeregrineValueTypes)
 
 ## Contributing
 

--- a/ValueTypes/README.md
+++ b/ValueTypes/README.md
@@ -1,5 +1,7 @@
 # Peregrine ValueTypes
 
+[![Version](https://img.shields.io/nuget/v/PeregrineValueTypes.svg?label=NuGet)](https://www.nuget.org/packages/PeregrineValueTypes)
+
 This library, which is part of the Peregrine series of code for real-time and performant applications, contains F# functions for manipulating data structures in ways that don't allocate. It tests this fact by using BenchmarkDotNet to assert that the number of allocations made by its functions are zero.
 
 The core modules of this library are:

--- a/version.json
+++ b/version.json
@@ -3,5 +3,11 @@
   "version": "2.1",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
-  ]
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+     },
+     "setVersionVariables": true
+  }
 }


### PR DESCRIPTION
* Appveyor was reporting the build version using its own internal numbering scheme; GitVersioning supports pushing the package version to Appveyor so have enabled that in `version.json`
* Added a badge to the README files that says what the current version released to NuGet is.